### PR TITLE
Current state is saved to local storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
-  "name": "Sankeyfactory",
+  "name": "sankeyfactory.github.io",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "dependencies": {
-        "panzoom": "^9.4.3",
-        "typescript": "^5.5.4"
+        "panzoom": "^9.4.3"
       },
       "devDependencies": {
         "@types/node": "^22.2.0",
         "esbuild": "^0.23.0",
-        "gh-pages": "^6.1.1"
+        "gh-pages": "^6.1.1",
+        "typescript": "^5.5.4"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -983,6 +983,7 @@
       "version": "5.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/src/AppData.ts
+++ b/src/AppData.ts
@@ -45,6 +45,13 @@ export class AppData extends EventTarget
     public static loadFromUrl()
     {
         let dataEncoded = location.hash.slice(1);
+        let dataEncodedFromStorage = this.loadFromLocalStorage();
+
+        if (dataEncoded == ``) {
+            dataEncoded = dataEncodedFromStorage;
+            location.hash = dataEncoded;
+        } 
+
         if (dataEncoded == ``) return;
 
         let savedData = atob(decodeURI(dataEncoded));
@@ -69,10 +76,19 @@ export class AppData extends EventTarget
             let savedData = AppData.serialize();
 
             let dataEncoded = encodeURI(btoa(savedData));
+            this.saveToLocalStorage(dataEncoded);
 
             location.hash = dataEncoded;
         }
     }
+
+    private static saveToLocalStorage(data: string) {
+        localStorage.setItem('saveState', data);
+      }
+    
+      static loadFromLocalStorage(): string {
+        return localStorage.getItem('saveState') ?? '';
+      }
 
     public static lockSaving()
     {


### PR DESCRIPTION
The current state of nodes is always saved to local storage in the browser. This to make it easier to continue working on larger plans, and getting back to the same state. 