### PR TITLE
Fix #2 by using esbuild servedir (and watch) features

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build-satisfactory-icon-exporter": "npx esbuild --platform=node src/Tools/SatisfactoryIconExporter/Exporter.ts --bundle --sourcemap --outfile=src/Tools/SatisfactoryIconExporter/Exporter.js",
     "export-satisfactory-icons": "npm run build-satisfactory-icon-exporter && node src/Tools/SatisfactoryIconExporter/Exporter.js",
     "build-app": "npx esbuild src/main.ts --bundle --outfile=dist/script.js",
-    "build-app-prod": "npx esbuild src/main.ts --bundle --minify=true --outfile=dist/script.js"
+    "build-app-prod": "npx esbuild src/main.ts --bundle --minify=true --outfile=dist/script.js",
+    "start": "npx esbuild src/main.ts --bundle --watch --outfile=dist/script.js --servedir=dist"
   }
 }


### PR DESCRIPTION
Just use `npm run start` (or `npm start`) and open https://localhost:8000 in your browser.
Modify the source code and reload your browser :)

Idea provided by @andev0 in [this comment](https://github.com/Sankeyfactory/sankeyfactory.github.io/issues/2#issuecomment-2328075445) 🙇🏻 