### PR TITLE
Feature: Add building display count to summary.

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -113,6 +113,9 @@
                 <div class="column outputs">
                     <div class="title">Factory outputs</div>
                 </div>
+                <div class="column buildings">
+                    <div class="title">Buildings</div>
+                </div>
             </div>
             <div class="collapse-button button dimmed">
                 <svg class="chevron-up_icon-placeholder"></svg>

--- a/dist/style.css
+++ b/dist/style.css
@@ -1368,7 +1368,7 @@ div#resources-summary {
     left: 0;
     top: 0;
 
-    width: 360px;
+    width: 520px;
     max-width: 100%;
     max-height: 100%;
 }

--- a/src/ResourcesSummary.ts
+++ b/src/ResourcesSummary.ts
@@ -2,6 +2,7 @@ import { SankeyNode } from "./Sankey/SankeyNode";
 import { loadSatisfactoryResource, satisfactoryIconPath } from './GameData/GameData';
 import { SvgIcons } from './DomUtils/SvgIcons';
 import { HtmlUtils } from "./DomUtils/HtmlUtils";
+import {GameMachine} from "./GameData/GameMachine";
 
 export class ResourcesSummary
 {
@@ -21,6 +22,7 @@ export class ResourcesSummary
 
         this.recalculateInputs();
         this.recalculateOutputs();
+        this.recalculateBuildings();
     }
 
     public registerNode(node: SankeyNode)
@@ -29,11 +31,13 @@ export class ResourcesSummary
 
         this.recalculateInputs();
         this.recalculateOutputs();
+        this.recalculateBuildings();
 
         node.addEventListener(SankeyNode.changedVacantResourcesAmountEvent, () =>
         {
             this.recalculateInputs();
             this.recalculateOutputs();
+            this.recalculateBuildings();
         });
 
         node.addEventListener(SankeyNode.deletionEvent, () =>
@@ -44,6 +48,7 @@ export class ResourcesSummary
 
             this.recalculateInputs();
             this.recalculateOutputs();
+            this.recalculateBuildings();
         });
     }
 
@@ -71,7 +76,7 @@ export class ResourcesSummary
             requiredPowerShards += node.requiredPowerShards;
         }
 
-        this.recalculate(ResourcesSummary._inputsColumn, resources, powerConsumption, requiredPowerShards);
+        this.recalculateResourceColumn(ResourcesSummary._inputsColumn, resources, powerConsumption, requiredPowerShards);
     }
 
     private recalculateOutputs(): void
@@ -89,10 +94,47 @@ export class ResourcesSummary
             }
         }
 
-        this.recalculate(ResourcesSummary._outputsColumn, resources, 0, 0);
+        this.recalculateResourceColumn(ResourcesSummary._outputsColumn, resources, 0, 0);
     }
 
-    private recalculate(
+    private recalculateBuildings(): void
+    {
+        // Clear old entries
+        ResourcesSummary._buildingsColumn.querySelectorAll(".resource").forEach(r => r.remove());
+
+        let isAnyAdded = false;
+        let buildings = new Map<string, { machine: GameMachine, amount: number }>();
+
+        for (const node of this._nodes) {
+            let key = node.machine.displayName;
+            if (!buildings.has(key)) {
+                buildings.set(key, { machine: node.machine, amount: 0 });
+            }
+            buildings.get(key)!.amount += Math.ceil(node.machinesAmount);
+        }
+
+        for (const [, { machine, amount }] of buildings) {
+            ResourcesSummary._buildingsColumn.appendChild(this.createBuildingDisplay(machine, amount));
+            isAnyAdded = true;
+        }
+
+        if (!isAnyAdded)
+        {
+            let noneText = HtmlUtils.createHtmlElement("div", "resource", "none");
+            noneText.innerText = "None";
+            ResourcesSummary._buildingsColumn.appendChild(noneText);
+        }
+
+        // Respect collapse state
+        if (this._isCollapsed)
+        {
+            ResourcesSummary.setCollapsingAnimationEnabled(false);
+            this.hideContent();
+            ResourcesSummary.setCollapsingAnimationEnabled(true);
+        }
+    }
+
+    private recalculateResourceColumn(
         column: HTMLDivElement,
         resources: Map<string, number>,
         powerConsumption: number,
@@ -216,6 +258,24 @@ export class ResourcesSummary
         return powerDisplay;
     }
 
+    private createBuildingDisplay(building: GameMachine, amount: number): HTMLDivElement
+    {
+        let buildingDisplay = HtmlUtils.createHtmlElement("div", "resource");
+
+        let iconPath = satisfactoryIconPath(building.iconPath);
+        let icon = HtmlUtils.createHtmlElement("img", "icon");
+        icon.src = iconPath;
+        icon.title = building.displayName;
+        icon.alt = building.displayName;
+
+        let amountDisplay = HtmlUtils.createHtmlElement("div", "amount");
+        amountDisplay.innerText = `${amount}x`;
+
+        buildingDisplay.appendChild(icon);
+        buildingDisplay.appendChild(amountDisplay);
+        return buildingDisplay;
+    }
+
     private static querySuccessor(query: string): Element
     {
         let element = ResourcesSummary._summaryContainer.querySelector(`${query}`);
@@ -244,6 +304,8 @@ export class ResourcesSummary
         ResourcesSummary.querySuccessor(".column.inputs") as HTMLDivElement;
     private static readonly _outputsColumn =
         ResourcesSummary.querySuccessor(".column.outputs") as HTMLDivElement;
+    private static readonly _buildingsColumn =
+        ResourcesSummary.querySuccessor(".column.buildings") as HTMLDivElement;
 
     private static readonly _collapseButton =
         ResourcesSummary.querySuccessor(".collapse-button") as HTMLDivElement;

--- a/src/ResourcesSummary.ts
+++ b/src/ResourcesSummary.ts
@@ -2,7 +2,7 @@ import { SankeyNode } from "./Sankey/SankeyNode";
 import { loadSatisfactoryResource, satisfactoryIconPath } from './GameData/GameData';
 import { SvgIcons } from './DomUtils/SvgIcons';
 import { HtmlUtils } from "./DomUtils/HtmlUtils";
-import {GameMachine} from "./GameData/GameMachine";
+import { GameMachine } from "./GameData/GameMachine";
 
 export class ResourcesSummary
 {

--- a/src/Sankey/SankeyNode.ts
+++ b/src/Sankey/SankeyNode.ts
@@ -470,4 +470,8 @@ export class SankeyNode extends EventTarget
     private static _nextId = 0;
 
     private static readonly _nodeHeight = 300;
+
+    public get machine(): GameMachine {
+        return this._machine;
+    }
 }


### PR DESCRIPTION
Adds a building count to the summary.
The totals are calculated by taking the sum of the ceilings of each node, so that having two 0.5x buildings with different recipes is outputted as `2` and not `1`, as each building can only have one recipe.
I might need to work on the styling of the column a little.

### Before:
<img width="360" height="212" alt="image" src="https://github.com/user-attachments/assets/320597f6-453b-4056-9afc-3f9faafee756" />

### After:
<img width="520" height="212" alt="image" src="https://github.com/user-attachments/assets/3903c2d4-bdd0-4fdd-87ed-efd6e2fa2099" />

Edit: Fixes #24 